### PR TITLE
Feature: add http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,14 @@
 package requestfy
 
-type Client struct{}
+import "net/http"
+
+type RequestExecuter interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	executer RequestExecuter
+}
 
 type ClientConfig func(*Client)
 
@@ -12,4 +20,10 @@ func NewClient(configs ...ClientConfig) *Client {
 	}
 
 	return client
+}
+
+func ConfigRequestExecuter(executer RequestExecuter) ClientConfig {
+	return func(c *Client) {
+		c.executer = executer
+	}
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,15 @@
+package requestfy
+
+type Client struct{}
+
+type ClientConfig func(*Client)
+
+func NewClient(configs ...ClientConfig) *Client {
+	client := &Client{}
+
+	for i := range configs {
+		configs[i](client)
+	}
+
+	return client
+}

--- a/client.go
+++ b/client.go
@@ -2,14 +2,17 @@ package requestfy
 
 import "net/http"
 
+// RequestExecuter abstracts the http client used behind the scenes to perform HTTP requests
 type RequestExecuter interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
+// Client Allows you to perform http requests with a simple syntax
 type Client struct {
 	executer RequestExecuter
 }
 
+// ClientConfig is a function to configure the client
 type ClientConfig func(*Client)
 
 func NewClient(configs ...ClientConfig) *Client {
@@ -22,6 +25,7 @@ func NewClient(configs ...ClientConfig) *Client {
 	return client
 }
 
+// ConfigRequestExecuter allows you to specify an http request executor for the client
 func ConfigRequestExecuter(executer RequestExecuter) ClientConfig {
 	return func(c *Client) {
 		c.executer = executer

--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ type RequestExecuter interface {
 // Client Allows you to perform http requests with a simple syntax
 type Client struct {
 	executer RequestExecuter
+	baseURL  string
 }
 
 // ClientConfig is a function to configure the client
@@ -29,6 +30,13 @@ func NewClient(configs ...ClientConfig) *Client {
 func ConfigRequestExecuter(executer RequestExecuter) ClientConfig {
 	return func(c *Client) {
 		c.executer = executer
+	}
+}
+
+// ConfigBaseURL specifies a prefix, a base to apply to the URL of all client requests
+func ConfigBaseURL(baseURL string) ClientConfig {
+	return func(c *Client) {
+		c.baseURL = baseURL
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -31,3 +31,10 @@ func ConfigRequestExecuter(executer RequestExecuter) ClientConfig {
 		c.executer = executer
 	}
 }
+
+// ConfigDefault configures the client with default options to allow quick start
+func ConfigDefault() ClientConfig {
+	return func(c *Client) {
+		c.executer = http.DefaultClient
+	}
+}


### PR DESCRIPTION
- Added structure to store HTTP client configuration
- Added function based client configuration to allow configuration evolution without modifying or adding other client creation methods
- Added interface to abstract to `http.Client`
- Added function to specify HTTP request executor
- Added function configure the client with default options

This PR resolves #1 and resolves #2