### PR TITLE
Send PUT request

### DIFF
--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package requestfy
 
 import (
 	"context"
+	"io"
 	"net/http"
 )
 
@@ -14,6 +15,16 @@ type Request struct {
 // Get performs a request using the GET method
 func (r *Request) Get(url string) (*Response, error) {
 	req, err := r.client.newRequest(r.context, url, http.MethodGet, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.client.doRequest(req)
+}
+
+// Put performs a request using the PUT method
+func (r *Request) Put(url string, body io.Reader) (*Response, error) {
+	req, err := r.client.newRequest(r.context, url, http.MethodPut, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/request.go
+++ b/request.go
@@ -24,7 +24,7 @@ func (r *Request) Get(url string) (*Response, error) {
 
 // Put performs a request using the PUT method
 func (r *Request) Put(url string, body io.Reader) (*Response, error) {
-	req, err := r.client.newRequest(r.context, url, http.MethodPut, nil)
+	req, err := r.client.newRequest(r.context, url, http.MethodPut, body)
 	if err != nil {
 		return nil, err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -2,6 +2,7 @@ package requestfy_test
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -14,24 +15,36 @@ const path = "cool/path"
 func TestRequests(t *testing.T) {
 	testCases := []struct {
 		expectedMethod string
-		method         func(*requestfy.Request) func(string) (*requestfy.Response, error)
+		method         func(*requestfy.Request) func(string, io.Reader) (*requestfy.Response, error)
 	}{
 		{
 			http.MethodGet,
-			func(r *requestfy.Request) func(string) (*requestfy.Response, error) {
-				return r.Get
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return func(s string, body io.Reader) (*requestfy.Response, error) {
+					return r.Get(s)
+				}
+			},
+		},
+		{
+			http.MethodPut,
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return r.Put
 			},
 		},
 		{
 			http.MethodDelete,
-			func(r *requestfy.Request) func(string) (*requestfy.Response, error) {
-				return r.Delete
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return func(s string, body io.Reader) (*requestfy.Response, error) {
+					return r.Delete(s)
+				}
 			},
 		},
 		{
 			http.MethodHead,
-			func(r *requestfy.Request) func(string) (*requestfy.Response, error) {
-				return r.Head
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return func(s string, body io.Reader) (*requestfy.Response, error) {
+					return r.Head(s)
+				}
 			},
 		},
 	}
@@ -43,7 +56,7 @@ func TestRequests(t *testing.T) {
 				requestfy.ConfigBaseURL(fakeURL),
 			)
 
-			res, err := test.method(client.Request())(path)
+			res, err := test.method(client.Request())(path, nil)
 			assertRequestMethod(t, spy, res, err, test.expectedMethod)
 		})
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -41,10 +41,9 @@ func TestHeaders(t *testing.T) {
 					t.Error("headers are not equals")
 				}
 			}
-    	}
+		}
 	})
 }
-
 
 func TestRequests(t *testing.T) {
 	testCases := []struct {
@@ -83,14 +82,18 @@ func TestRequests(t *testing.T) {
 		},
 		{
 			http.MethodPatch,
-			func(r *requestfy.Request) func(string) (*requestfy.Response, error) {
-				return r.Patch
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return func(s string, body io.Reader) (*requestfy.Response, error) {
+					return r.Patch(s)
+				}
 			},
 		},
 		{
 			http.MethodOptions,
-			func(r *requestfy.Request) func(string) (*requestfy.Response, error) {
-				return r.Options
+			func(r *requestfy.Request) func(string, io.Reader) (*requestfy.Response, error) {
+				return func(s string, body io.Reader) (*requestfy.Response, error) {
+					return r.Options(s)
+				}
 			},
 		},
 	}


### PR DESCRIPTION
Now, we able to send HTTP request using PUT method by this way

```go
client.Request().Put("https://jsonplaceholder.typicode.com/posts/1", nil)
```

Fixes #6 

This is unit test result on this changes.
<img width="623" alt="image" src="https://user-images.githubusercontent.com/16364286/193761313-b0279757-6f69-478e-a514-d0003f0bf519.png">

cc @RafaelYon 